### PR TITLE
Implement automatic pagination

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ export default {
       useESM: true,
     },
   },
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transformIgnorePatterns: ["/node_modules/(?!axios)/"],
   testPathIgnorePatterns: ["/dist/"],
 };

--- a/src/__tests__/devicesMethod.test.ts
+++ b/src/__tests__/devicesMethod.test.ts
@@ -5,6 +5,12 @@ import * as path from "path";
 const devicesPage = JSON.parse(
   fs.readFileSync(path.join(__dirname, "fixtures/devicesPage.json"), "utf-8"),
 );
+const devicesPage1 = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures/devicesPage1.json"), "utf-8"),
+);
+const devicesPage2 = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures/devicesPage2.json"), "utf-8"),
+);
 
 class MockAxios {
   requests: any[] = [];
@@ -39,10 +45,39 @@ test("getAccountDevices returns validated data", async () => {
 
   const result = await client.getAccountDevices();
   expect(result.ok).toBe(true);
-  const page = (result as any).value;
-  expect(page.devices?.length).toBe(1);
-  expect(page.devices?.[0].hostname).toBe("server1");
-  expect(page.devices?.[0].antivirus?.antivirusStatus).toBe(
-    "RunningAndUpToDate",
-  );
+  const devices = (result as any).value;
+  expect(devices.length).toBe(1);
+  expect(devices[0].hostname).toBe("server1");
+  expect(devices[0].antivirus?.antivirusStatus).toBe("RunningAndUpToDate");
+});
+
+test("getAccountDevices paginates automatically", async () => {
+  const responses = {
+    "https://example.com/auth/oauth/token": {
+      access_token: "token",
+      refresh_token: "r",
+      expires_in: 3600,
+    },
+    "https://example.com/api/v2/account/devices": devicesPage1,
+    "https://example.com/api/v2/account/devices?page=2": devicesPage2,
+  };
+  const mockAxios = new MockAxios(responses) as any;
+
+  const client = createDattoRmmClient({
+    apiUrl: "https://example.com",
+    apiKey: "k",
+    apiSecret: "s",
+    axiosInstance: mockAxios,
+  });
+
+  const result = await client.getAccountDevices();
+  expect(result.ok).toBe(true);
+  const devices = (result as any).value;
+  expect(devices.length).toBe(2);
+  expect(devices[1].hostname).toBe("server2");
+  expect(mockAxios.requests.map((r: any) => r.url)).toEqual([
+    "https://example.com/auth/oauth/token",
+    "https://example.com/api/v2/account/devices",
+    "https://example.com/api/v2/account/devices?page=2",
+  ]);
 });

--- a/src/__tests__/fixtures/devicesPage1.json
+++ b/src/__tests__/fixtures/devicesPage1.json
@@ -1,0 +1,58 @@
+{
+  "pageDetails": {
+    "count": 1,
+    "totalCount": 2,
+    "prevPageUrl": "",
+    "nextPageUrl": "https://example.com/api/v2/account/devices?page=2"
+  },
+  "devices": [
+    {
+      "id": 1,
+      "uid": "device-uid-1",
+      "siteId": 100,
+      "siteUid": "site-uid-1",
+      "siteName": "Main Site",
+      "deviceType": {
+        "category": "server",
+        "type": "physical"
+      },
+      "hostname": "server1",
+      "intIpAddress": "192.168.1.10",
+      "operatingSystem": "Windows Server 2019",
+      "lastLoggedInUser": "admin",
+      "domain": "example.local",
+      "cagVersion": "10.1.0",
+      "displayVersion": "10.1.0.1234",
+      "extIpAddress": "203.0.113.5",
+      "description": "Primary server",
+      "a64Bit": true,
+      "rebootRequired": false,
+      "online": true,
+      "suspended": false,
+      "deleted": false,
+      "lastSeen": "2024-07-16T12:00:00Z",
+      "lastReboot": "2024-07-15T06:00:00Z",
+      "lastAuditDate": "2024-07-15T06:05:00Z",
+      "creationDate": "2024-01-01T00:00:00Z",
+      "udf": {
+        "udf1": "value1"
+      },
+      "snmpEnabled": false,
+      "deviceClass": "device",
+      "portalUrl": "https://rmm.datto.com/devices/1",
+      "warrantyDate": "2026-01-01",
+      "antivirus": {
+        "antivirusProduct": "Windows Defender",
+        "antivirusStatus": "RunningAndUpToDate"
+      },
+      "patchManagement": {
+        "patchStatus": "FullyPatched",
+        "patchesApprovedPending": 0,
+        "patchesNotApproved": 0,
+        "patchesInstalled": 100
+      },
+      "softwareStatus": "OK",
+      "webRemoteUrl": "https://webremote.datto.com/connect/1"
+    }
+  ]
+}

--- a/src/__tests__/fixtures/devicesPage2.json
+++ b/src/__tests__/fixtures/devicesPage2.json
@@ -1,0 +1,58 @@
+{
+  "pageDetails": {
+    "count": 1,
+    "totalCount": 2,
+    "prevPageUrl": "https://example.com/api/v2/account/devices?page=1",
+    "nextPageUrl": ""
+  },
+  "devices": [
+    {
+      "id": 2,
+      "uid": "device-uid-2",
+      "siteId": 100,
+      "siteUid": "site-uid-1",
+      "siteName": "Main Site",
+      "deviceType": {
+        "category": "server",
+        "type": "physical"
+      },
+      "hostname": "server2",
+      "intIpAddress": "192.168.1.11",
+      "operatingSystem": "Windows Server 2019",
+      "lastLoggedInUser": "admin",
+      "domain": "example.local",
+      "cagVersion": "10.1.0",
+      "displayVersion": "10.1.0.1234",
+      "extIpAddress": "203.0.113.6",
+      "description": "Secondary server",
+      "a64Bit": true,
+      "rebootRequired": false,
+      "online": true,
+      "suspended": false,
+      "deleted": false,
+      "lastSeen": "2024-07-16T12:00:00Z",
+      "lastReboot": "2024-07-15T06:00:00Z",
+      "lastAuditDate": "2024-07-15T06:05:00Z",
+      "creationDate": "2024-01-01T00:00:00Z",
+      "udf": {
+        "udf1": "value2"
+      },
+      "snmpEnabled": false,
+      "deviceClass": "device",
+      "portalUrl": "https://rmm.datto.com/devices/2",
+      "warrantyDate": "2026-01-01",
+      "antivirus": {
+        "antivirusProduct": "Windows Defender",
+        "antivirusStatus": "RunningAndUpToDate"
+      },
+      "patchManagement": {
+        "patchStatus": "FullyPatched",
+        "patchesApprovedPending": 0,
+        "patchesNotApproved": 0,
+        "patchesInstalled": 100
+      },
+      "softwareStatus": "OK",
+      "webRemoteUrl": "https://webremote.datto.com/connect/2"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- map `.js` imports to `.ts` for Jest
- abstract pagination into `fetchAllPages`
- use new helper in `getAccountDevices`
- test pagination behavior

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687ea5677e10832e81019b389a0df978