### PR TITLE
ci: make npm publish idempotent (bump to 0.1.10)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,4 +78,21 @@ jobs:
       # --access public because the package is unscoped/public.
       - name: Publish to npm
         if: steps.check.outputs.published == 'false'
-        run: npm publish --access public --provenance
+        shell: bash
+        run: |
+          set -uo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm publish --access public --provenance; then
+            echo "Published ${NAME}@${VERSION}"
+          # npm can report failure *after* actually publishing: its internal
+          # retry re-sends the request and hits "cannot publish over previously
+          # published", failing the step even though the release went through.
+          # Re-check the registry and treat an existing version as success;
+          # only fail if the version is genuinely missing.
+          elif npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::${NAME}@${VERSION} already on npm — treating publish as successful."
+          else
+            echo "::error::Publish failed and ${NAME}@${VERSION} is not on npm."
+            exit 1
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datto-rmm-api-client",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datto-rmm-api-client",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-rmm-api-client",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "ESM-only server-side TypeScript client for Datto RMM API v2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why
When PR #17 merged, the publish workflow **published `0.1.9` successfully (it's live on npm with SLSA provenance)** but the step still went red. npm's internal retry re-sent the publish after the first attempt succeeded and got `cannot publish over previously published: 0.1.9`, failing the step after the fact.

The existing "already published" guard covers *re-runs* and the *next push*, but not this *intra-run* retry-after-success race.

## Change
Make the `Publish to npm` step idempotent: if `npm publish` exits non-zero, re-check the registry and treat an **already-present version as success** — only fail when the version is genuinely missing.

```
if npm publish ...; then ok
elif npm view NAME@VERSION exists; then treat as success
else real failure
```

## Version
Bumps `0.1.9 → 0.1.10` to satisfy the version-bump gate. This is a workflow-only change, so `0.1.10` publishes functionally identical code to `0.1.9` — the unavoidable cost of "every merge publishes" (same tradeoff as fuze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)