### PR TITLE
chore(deps): bump actions/checkout and actions/setup-node (2026-07-03)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
       # npm ci + lint + typecheck + test. Inlined (rather than calling
       # pncit/shared-actions) because that repo is private and a public repo
       # can't resolve a private org action.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
@@ -33,7 +33,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
       # pncit/shared-actions) because that repo is private and a public repo
       # can't resolve a private org action.
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ jobs:
       # fetch of the base branch gives the version-bump gate the base
       # package.json to diff against.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,7 +75,7 @@ jobs:
       # calling pncit/shared-actions) because that repo is private and a public
       # repo can't resolve a private org action.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datto-rmm-api-client",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datto-rmm-api-client",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-rmm-api-client",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "ESM-only server-side TypeScript client for Datto RMM API v2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Batched Dependabot updates (GitHub Actions)

Follow-up to #25. #18 and #19 were originally held under the blanket
major-version-bump policy; re-evaluated their changelogs and this repo's
actual usage and found no risk, so incorporating them here.

### Incorporated
- #18 `actions/checkout` 4 → 7 (major)
- #19 `actions/setup-node` 4 → 6 (major)

### Why these are safe here
- **actions/checkout v7's** only breaking change is blocking fork-PR checkout
  for `pull_request_target`/`workflow_run` events. This repo's workflows only
  trigger on `push` (npm-publish.yml) and `pull_request` (validate.yml) — not
  affected.
- **actions/setup-node v5/v6's** breaking changes are around automatic cache
  detection driven by a `packageManager` field in `package.json`. This repo
  has no `packageManager` field, and every usage already sets `cache: npm`
  explicitly. v6 additionally narrows automatic caching to npm only, which is
  what we already use.
- Both actions' newer Node runtime requirements are satisfied by GitHub-hosted
  `ubuntu-latest` runners.

### Version
Bumped `package.json` 0.1.12 → 0.1.13 (patch) to satisfy release validation.

### Validation
- [x] `npm ci && npm run lint && npm run typecheck && npm run build && npm test` pass locally
- [x] CI on this PR is green (workflow changes only take effect once run on GitHub)

Once merged, Dependabot auto-closes #18 and #19 on its next scan.
