### PR TITLE
fix: remove recursive publish script that breaks every release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datto-rmm-api-client",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datto-rmm-api-client",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-rmm-api-client",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "ESM-only server-side TypeScript client for Datto RMM API v2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,8 +12,7 @@
     "lint:fix": "eslint src --fix",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run clean && npm run build && npm test",
-    "publish": "npm publish --access public"
+    "prepublishOnly": "npm run clean && npm run build && npm test"
   },
   "keywords": [],
   "author": "Rob Gilbreath",


### PR DESCRIPTION
## Problem

The `publish-on-version-bump` workflow's `Publish to npm` step keeps
failing after a *successful* publish (most recently for 0.1.13:
https://github.com/pncit/datto-rmm-api-client/actions/runs/28691663907/job/85093993678).

`package.json` had a script literally named `"publish"`:

```json
"publish": "npm publish --access public"
```

`publish` is a **reserved npm lifecycle-hook name**. Any real `npm publish`
invocation (CI's or a human's) triggers this script again as a post-publish
hook — after the package uploads successfully, npm re-runs
`npm publish --access public`, which re-builds/re-tests and tries to upload
the *same version again*. The registry correctly rejects it:

```
npm error code E403
npm error 403 Forbidden - PUT https://registry.npmjs.org/datto-rmm-api-client
npm error 403 You cannot publish over the previously published versions: 0.1.13.
```

That nested failure makes the outer `npm publish` command (the one the
workflow runs) exit non-zero, so the job reports failure even though the
actual publish already succeeded — 0.1.13 is confirmed live on npm right now.

This is a pre-existing, unconditional bug (present since the very first
commit that added npm publishing, `759eb16`) — it would fail identically on
every future publish, not just this one.

## Why PR validation didn't catch it

`validate.yml` never invokes the real `npm publish` command — deliberately,
since doing so from a PR would attempt a real registry publish. This bug only
manifests when `npm publish` genuinely runs, which by design only happens in
the post-merge `publish` job. A `--dry-run` check in PR validation wouldn't
have helped either: the recursive nested script doesn't inherit `--dry-run`,
so it would trigger an *actual* uncontrolled publish attempt from every PR —
worse, not better.

## Fix

Delete the `publish` script. Nothing invokes `npm run publish` — CI calls
`npm publish` directly, and `publishConfig.access` already covers
`--access public`. Verified locally with `npm publish --dry-run` that
`prepublishOnly`/pack/publish now run exactly once (no recursion).

### Validation
- [x] `npm ci && npm run lint && npm run typecheck && npm run build && npm test` pass locally
- [x] `npm publish --dry-run` shows a single, non-recursive publish flow
- Version bumped 0.1.13 → 0.1.14 to satisfy the release-validation gate